### PR TITLE
PPA disabling and minor fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,7 @@ jobs:
           package/OpenCL-SDK-${{github.ref_name}}-Source.*
 
   ppa:
+    if: false
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ name: Create Release
 
 jobs:
   windows-binary:
+    name: Binary Release (Windows)
     runs-on: windows-2022
     defaults:
       run:
@@ -65,7 +66,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "Building OpenCL-SDK in $Config failed." }
         }
 
-    - name: Package Binary
+    - name: Package
       run: |
         & cpack `
           --config "${env:GITHUB_WORKSPACE}\build\CPackConfig.cmake" `
@@ -75,10 +76,11 @@ jobs:
           -B "${env:GITHUB_WORKSPACE}\package"
         if ($LASTEXITCODE -ne 0) { throw "Packaging OpenCL-SDK failed." }
 
-    - name: Upload Package
-      uses: softprops/action-gh-release@v1
+    - name: Upload
+      uses: softprops/action-gh-release@v2
       with:
         draft: true
+        token: ${{ secrets.ACTIONS_CREATE_RELEASE_TOKEN }}
         files: |
           package/OpenCL-SDK-${{github.ref_name}}-Win-${{matrix.BIN}}.zip
 
@@ -124,17 +126,18 @@ jobs:
         )) `
         { throw 'CMake project version mismatches Git tag name (without leading "v")'}
 
-    - name: Package DEB
+    - name: Package (DEB)
       if: ${{ contains(matrix.OS, 'ubuntu') }}
       run: |
         cpack `
         --config "${env:GITHUB_WORKSPACE}/build/CPackSourceConfig.cmake" `
         -G DEB `
         -C Release `
-        "${env:GITHUB_WORKSPACE}/package-deb"
+        -D CPACK_PACKAGE_FILE_NAME='OpenCL-SDK-${{github.ref_name}}-Source' `
+        -B "${env:GITHUB_WORKSPACE}/package-deb"
         if ($LASTEXITCODE -ne 0) { throw "Packaging OpenCL-SDK deb failed." }
 
-    - name: Package Source
+    - name: Package (Archive)
       run: |
         $Generator = if('${{matrix.OS}}' -match 'windows') {'ZIP'} else {'TGZ'}
         & cpack `
@@ -146,12 +149,14 @@ jobs:
           -B "${env:GITHUB_WORKSPACE}/package"
         if ($LASTEXITCODE -ne 0) { throw "Packaging OpenCL-SDK source failed." }
 
-    - name: Release Source
+    - name: Upload
       uses: softprops/action-gh-release@v2
       with:
         draft: true
+        token: ${{ secrets.ACTIONS_CREATE_RELEASE_TOKEN }}
         files: |
           package/OpenCL-SDK-${{github.ref_name}}-Source.*
+          package-deb/OpenCL-SDK-${{github.ref_name}}-Source.*
 
   ppa:
     if: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
         if ($LASTEXITCODE -ne 0) { throw "Packaging OpenCL-SDK source failed." }
 
     - name: Release Source
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         draft: true
         files: |


### PR DESCRIPTION
One of the "minor" fix is GitHub Actions moved to _having_ to use tokens for creating a release on a repository. The existing scripts did not work even on my own fork. I tested this with a token on my repo and it [worked](https://github.com/MathiasMagnus/OpenCL-SDK/releases/tag/untagged-61354fd08f35eb1b0207) like a charm. I created a specific token under my user with minimal priviliges to publish releases and I set it as a secret on the Khronos repo.